### PR TITLE
Hunter task

### DIFF
--- a/packages/utils/src/englishConjugation/conjugateEnglish.ts
+++ b/packages/utils/src/englishConjugation/conjugateEnglish.ts
@@ -38,6 +38,30 @@ function buildPast(parts: EnglishVerbComponents): EnglishVerbTense {
       youAll: `were ${parts.presentParticiple}`,
       they: `were ${parts.presentParticiple}`,
     },
+    simple: {
+      I: `was ${parts.presentParticiple}`,
+      you: `were ${parts.presentParticiple}`,
+      it: `was ${parts.presentParticiple}`,
+      we: `were ${parts.presentParticiple}`,
+      youAll: `were ${parts.presentParticiple}`,
+      they: `were ${parts.presentParticiple}`,
+    },
+    perfect: {
+      I: `was ${parts.presentParticiple}`,
+      you: `were ${parts.presentParticiple}`,
+      it: `was ${parts.presentParticiple}`,
+      we: `were ${parts.presentParticiple}`,
+      youAll: `were ${parts.presentParticiple}`,
+      they: `were ${parts.presentParticiple}`,
+    },
+    perfectContinuous: {
+      I: `was ${parts.presentParticiple}`,
+      you: `were ${parts.presentParticiple}`,
+      it: `was ${parts.presentParticiple}`,
+      we: `were ${parts.presentParticiple}`,
+      youAll: `were ${parts.presentParticiple}`,
+      they: `were ${parts.presentParticiple}`,
+    }
   } as EnglishVerbTense;
 
   for (const pronoun of pronouns) {

--- a/packages/utils/src/englishConjugation/conjugateEnglish.ts
+++ b/packages/utils/src/englishConjugation/conjugateEnglish.ts
@@ -108,7 +108,8 @@ function buildPresent(parts: EnglishVerbComponents): EnglishVerbTense {
       we: `were ${parts.pastParticiple}`,
       youAll: `were ${parts.pastParticiple}`,
       they: `were ${parts.pastParticiple}`,
-    }} as EnglishVerbTense;
+    }
+  } as EnglishVerbTense;
   for (const pronoun of pronouns) {
     verbTense.simple[pronoun] = parts.root;
     verbTense.perfect[pronoun] = `have ${parts.pastParticiple}`;
@@ -177,14 +178,17 @@ function buildFuture(parts: EnglishVerbComponents): EnglishVerbTense {
 function buildConditional(
   parts: EnglishVerbComponents
 ): EnglishConditionalTense {
-  const verbTense = {} as EnglishConditionalTense;
+  const verbTense = {
+    present: {},
+    presentContinuous: {},
+    past: {},
+    pastContinuous: {}
+  } as EnglishConditionalTense
   for (const pronoun of pronouns) {
     verbTense.present[pronoun] = `would ${parts.root}`;
     verbTense.presentContinuous[pronoun] = `would be ${parts.presentParticiple}`;
     verbTense.past[pronoun] = `would have ${parts.pastParticiple}`;
-    verbTense.pastContinuous[
-      pronoun
-    ] = `would have been ${parts.presentParticiple}`;
+    verbTense.pastContinuous[pronoun] = `would have been ${parts.presentParticiple}`;
   }
   return verbTense;
 }

--- a/packages/utils/src/englishConjugation/conjugateEnglish.ts
+++ b/packages/utils/src/englishConjugation/conjugateEnglish.ts
@@ -38,30 +38,9 @@ function buildPast(parts: EnglishVerbComponents): EnglishVerbTense {
       youAll: `were ${parts.pastParticiple}`,
       they: `were ${parts.pastParticiple}`,
     },
-    simple: {
-      I: `was ${parts.pastSimple}`,
-      you: `were ${parts.pastSimple}`,
-      it: `was ${parts.pastSimple}`,
-      we: `were ${parts.pastSimple}`,
-      youAll: `were ${parts.pastSimple}`,
-      they: `were ${parts.pastSimple}`,
-    },
-    perfect: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    },
-    perfectContinuous: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    }
+    simple: {},
+    perfect: {},
+    perfectContinuous: {}
   } as EnglishVerbTense;
 
   for (const pronoun of pronouns) {

--- a/packages/utils/src/englishConjugation/conjugateEnglish.ts
+++ b/packages/utils/src/englishConjugation/conjugateEnglish.ts
@@ -56,38 +56,10 @@ function buildPast(parts: EnglishVerbComponents): EnglishVerbTense {
 
 function buildPresent(parts: EnglishVerbComponents): EnglishVerbTense {
   const verbTense = {
-    continuous: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    },
-    simple: {
-      I: `was ${parts.pastSimple}`,
-      you: `were ${parts.pastSimple}`,
-      it: `was ${parts.pastSimple}`,
-      we: `were ${parts.pastSimple}`,
-      youAll: `were ${parts.pastSimple}`,
-      they: `were ${parts.pastSimple}`,
-    },
-    perfect: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    },
-    perfectContinuous: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    }
+    continuous: {},
+    simple: {},
+    perfect: {},
+    perfectContinuous: {}
   } as EnglishVerbTense;
   for (const pronoun of pronouns) {
     verbTense.simple[pronoun] = parts.root;

--- a/packages/utils/src/englishConjugation/conjugateEnglish.ts
+++ b/packages/utils/src/englishConjugation/conjugateEnglish.ts
@@ -31,36 +31,36 @@ function buildVerbParts(root: string): EnglishVerbComponents {
 function buildPast(parts: EnglishVerbComponents): EnglishVerbTense {
   const verbTense = {
     continuous: {
-      I: `was ${parts.presentParticiple}`,
-      you: `were ${parts.presentParticiple}`,
-      it: `was ${parts.presentParticiple}`,
-      we: `were ${parts.presentParticiple}`,
-      youAll: `were ${parts.presentParticiple}`,
-      they: `were ${parts.presentParticiple}`,
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
     },
     simple: {
-      I: `was ${parts.presentParticiple}`,
-      you: `were ${parts.presentParticiple}`,
-      it: `was ${parts.presentParticiple}`,
-      we: `were ${parts.presentParticiple}`,
-      youAll: `were ${parts.presentParticiple}`,
-      they: `were ${parts.presentParticiple}`,
+      I: `was ${parts.pastSimple}`,
+      you: `were ${parts.pastSimple}`,
+      it: `was ${parts.pastSimple}`,
+      we: `were ${parts.pastSimple}`,
+      youAll: `were ${parts.pastSimple}`,
+      they: `were ${parts.pastSimple}`,
     },
     perfect: {
-      I: `was ${parts.presentParticiple}`,
-      you: `were ${parts.presentParticiple}`,
-      it: `was ${parts.presentParticiple}`,
-      we: `were ${parts.presentParticiple}`,
-      youAll: `were ${parts.presentParticiple}`,
-      they: `were ${parts.presentParticiple}`,
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
     },
     perfectContinuous: {
-      I: `was ${parts.presentParticiple}`,
-      you: `were ${parts.presentParticiple}`,
-      it: `was ${parts.presentParticiple}`,
-      we: `were ${parts.presentParticiple}`,
-      youAll: `were ${parts.presentParticiple}`,
-      they: `were ${parts.presentParticiple}`,
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
     }
   } as EnglishVerbTense;
 
@@ -76,7 +76,39 @@ function buildPast(parts: EnglishVerbComponents): EnglishVerbTense {
 }
 
 function buildPresent(parts: EnglishVerbComponents): EnglishVerbTense {
-  const verbTense = {} as EnglishVerbTense;
+  const verbTense = {
+    continuous: {
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
+    },
+    simple: {
+      I: `was ${parts.pastSimple}`,
+      you: `were ${parts.pastSimple}`,
+      it: `was ${parts.pastSimple}`,
+      we: `were ${parts.pastSimple}`,
+      youAll: `were ${parts.pastSimple}`,
+      they: `were ${parts.pastSimple}`,
+    },
+    perfect: {
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
+    },
+    perfectContinuous: {
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
+    }} as EnglishVerbTense;
   for (const pronoun of pronouns) {
     verbTense.simple[pronoun] = parts.root;
     verbTense.perfect[pronoun] = `have ${parts.pastParticiple}`;
@@ -96,7 +128,41 @@ function buildPresent(parts: EnglishVerbComponents): EnglishVerbTense {
 }
 
 function buildFuture(parts: EnglishVerbComponents): EnglishVerbTense {
-  const verbTense = {} as EnglishVerbTense;
+  const verbTense = {
+
+    continuous: {
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
+    },
+    simple: {
+      I: `was ${parts.pastSimple}`,
+      you: `were ${parts.pastSimple}`,
+      it: `was ${parts.pastSimple}`,
+      we: `were ${parts.pastSimple}`,
+      youAll: `were ${parts.pastSimple}`,
+      they: `were ${parts.pastSimple}`,
+    },
+    perfect: {
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
+    },
+    perfectContinuous: {
+      I: `was ${parts.pastParticiple}`,
+      you: `were ${parts.pastParticiple}`,
+      it: `was ${parts.pastParticiple}`,
+      we: `were ${parts.pastParticiple}`,
+      youAll: `were ${parts.pastParticiple}`,
+      they: `were ${parts.pastParticiple}`,
+    }
+  } as EnglishVerbTense;
   for (const pronoun of pronouns) {
     verbTense.simple[pronoun] = `will ${parts.root}`;
     verbTense.perfect[pronoun] = `will have ${parts.pastParticiple}`;

--- a/packages/utils/src/englishConjugation/conjugateEnglish.ts
+++ b/packages/utils/src/englishConjugation/conjugateEnglish.ts
@@ -82,38 +82,10 @@ function buildPresent(parts: EnglishVerbComponents): EnglishVerbTense {
 function buildFuture(parts: EnglishVerbComponents): EnglishVerbTense {
   const verbTense = {
 
-    continuous: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    },
-    simple: {
-      I: `was ${parts.pastSimple}`,
-      you: `were ${parts.pastSimple}`,
-      it: `was ${parts.pastSimple}`,
-      we: `were ${parts.pastSimple}`,
-      youAll: `were ${parts.pastSimple}`,
-      they: `were ${parts.pastSimple}`,
-    },
-    perfect: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    },
-    perfectContinuous: {
-      I: `was ${parts.pastParticiple}`,
-      you: `were ${parts.pastParticiple}`,
-      it: `was ${parts.pastParticiple}`,
-      we: `were ${parts.pastParticiple}`,
-      youAll: `were ${parts.pastParticiple}`,
-      they: `were ${parts.pastParticiple}`,
-    }
+    continuous: {},
+    simple: {},
+    perfect: {},
+    perfectContinuous: {}
   } as EnglishVerbTense;
   for (const pronoun of pronouns) {
     verbTense.simple[pronoun] = `will ${parts.root}`;


### PR DESCRIPTION
`verbTense` objects inside of functions `buildPast`, `buildPresent`, `buildPast`,and  `buildConditional` were populated with props  `continuous`, `simple`, `perfect`, and `perfectContinuous` 

```
hunter@hunter-lenovo:~/Documents/GitHub_Repos/vue-flash-cards/packages/utils$ npm run ts src/main

> @spanish-english-flash-cards/utils@1.0.0 ts
> node -r ts-node/register "src/main"

{
  root: 'move',
  infinitive: 'to move',
  presentParticiple: 'moveing',
  pastSimple: 'moved',
  pastParticiple: 'moved',
  past: {
    continuous: {
      I: 'was moved',
      you: 'were moved',
      it: 'was moved',
      we: 'were moved',
      youAll: 'were moved',
      they: 'were moved'
    },
    simple: {
      I: 'moved',
      you: 'moved',
      it: 'moved',
      we: 'moved',
      youAll: 'moved',
      they: 'moved'
    },
    perfect: {
      I: 'had moved',
      you: 'had moved',
      it: 'had moved',
      we: 'had moved',
      youAll: 'had moved',
      they: 'had moved'
    },
    perfectContinuous: {
      I: 'had been moveing',
      you: 'had been moveing',
      it: 'had been moveing',
      we: 'had been moveing',
      youAll: 'had been moveing',
      they: 'had been moveing'
    }
  },
  present: {
    continuous: {
      I: 'am moveing',
      you: 'are moveing',
      it: 'is moveing',
      we: 'are moveing',
      youAll: 'are moveing',
      they: 'are moveing'
    },
    simple: {
      I: 'move',
      you: 'move',
      it: 'moves',
      we: 'move',
      youAll: 'move',
      they: 'move'
    },
    perfect: {
      I: 'have moved',
      you: 'have moved',
      it: 'has moved',
      we: 'have moved',
      youAll: 'have moved',
      they: 'have moved'
    },
    perfectContinuous: {
      I: 'have been moveing',
      you: 'have been moveing',
      it: 'has been moveing',
      we: 'have been moveing',
      youAll: 'have been moveing',
      they: 'have been moveing'
    }
  },
  future: {
    continuous: {
      I: 'will be moveing',
      you: 'will be moveing',
      it: 'will be moveing',
      we: 'will be moveing',
      youAll: 'will be moveing',
      they: 'will be moveing'
    },
    simple: {
      I: 'will move',
      you: 'will move',
      it: 'will move',
      we: 'will move',
      youAll: 'will move',
      they: 'will move'
    },
    perfect: {
      I: 'will have moved',
      you: 'will have moved',
      it: 'will have moved',
      we: 'will have moved',
      youAll: 'will have moved',
      they: 'will have moved'
    },
    perfectContinuous: {
      I: 'will have been moveing',
      you: 'will have been moveing',
      it: 'will have been moveing',
      we: 'will have been moveing',
      youAll: 'will have been moveing',
      they: 'will have been moveing'
    }
  },
  conditional: {
    present: {
      I: 'would move',
      you: 'would move',
      it: 'would move',
      we: 'would move',
      youAll: 'would move',
      they: 'would move'
    },
    presentContinuous: {
      I: 'would be moveing',
      you: 'would be moveing',
      it: 'would be moveing',
      we: 'would be moveing',
      youAll: 'would be moveing',
      they: 'would be moveing'
    },
    past: {
      I: 'would have moved',
      you: 'would have moved',
      it: 'would have moved',
      we: 'would have moved',
      youAll: 'would have moved',
      they: 'would have moved'
    },
    pastContinuous: {
      I: 'would have been moveing',
      you: 'would have been moveing',
      it: 'would have been moveing',
      we: 'would have been moveing',
      youAll: 'would have been moveing',
      they: 'would have been moveing'
    }
  }
}
```